### PR TITLE
Handle when a pid no longer exists by the time you try and kill it.

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -240,7 +240,12 @@ module Resque
           wpid or break
           worker = delete_worker(wpid)
           # TODO: close any file descriptors connected to worker, if any
-          log "Reaped resque worker[#{status.pid}] (status: #{status.exitstatus}) queues: #{worker.queues.join(",")}"
+          if worker.nil?
+            # this died before it could be killed, so it's not going to have any extra info
+            log "Tried to reap worker [#{status.pid}], but it had already died. (status: #{status.exitstatus})"
+          else
+            log "Reaped resque worker[#{status.pid}] (status: #{status.exitstatus}) queues: #{worker.queues.join(",")}"
+          end
         end
       rescue Errno::ECHILD, QuitNowException
       end


### PR DESCRIPTION
Sometimes, ruby spawns a child which dies right away. It's an edge case and there's probably some other underlying issue, but this patch handles the case where that child wasn't able to be properly killed - and therefore you don't have any info about which queues exist.

this at least enables resque-pool to go on living.. but obviously it's not the cleanest fix out there. :/
