### PR TITLE
undefined method 'e' for error catching

### DIFF
--- a/lib/resque/pool/cli.rb
+++ b/lib/resque/pool/cli.rb
@@ -84,7 +84,7 @@ where [options] are:
         false
       rescue Errno::EPERM
         true
-      rescue ::Exception
+      rescue ::Exception => e
         $stderr.puts "While checking if PID #{old_pid} is running, unexpected #{e.class}: #{e}"
         true
       end


### PR DESCRIPTION
noticed this when i incorrectly passed -p a directory instead of a file
