### PR TITLE
Use Rails.env instead of RAILS_ENV

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    SystemTimer (1.2.3)
     aruba (0.4.11)
       childprocess (>= 0.2.3)
       cucumber (>= 1.1.1)
@@ -69,7 +68,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  SystemTimer
   aruba (~> 0.4.11)
   bundler (~> 1.0)
   cucumber (~> 1.2.0)

--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -102,6 +102,8 @@ module Resque
     def environment
       if defined? RAILS_ENV
         RAILS_ENV
+      elsif defined?(Rails) && Rails.respond_to?(:env)
+        Rails.env
       else
         ENV['RACK_ENV'] || ENV['RAILS_ENV'] || ENV['RESQUE_ENV']
       end

--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -59,6 +59,30 @@ describe Resque::Pool, "when loading the pool configuration from a Hash" do
 
   end
 
+  context "when Rails.env is set" do
+    before(:each) do
+      module Rails; end
+      Rails.stub(:env).and_return('test')
+    end
+
+    it "should load the default values from the Hash" do
+      subject.config["foo"].should == 8
+    end
+
+    it "should merge the values for the correct RAILS_ENV" do
+      subject.config["bar"].should == 10
+      subject.config["foo,bar"].should == 12
+    end
+
+    it "should not load the values for the other environments" do
+      subject.config["foo,bar"].should == 12
+      subject.config["baz"].should be_nil
+    end
+
+    after(:all) { Object.send(:remove_const, :Rails) }
+  end
+
+
   context "when ENV['RESQUE_ENV'] is set" do
     before { ENV['RESQUE_ENV'] = 'development' }
     it "should load the config for that environment" do


### PR DESCRIPTION
`RAILS_ENV` (the Ruby constant) is deprecated and has been removed in Rails 3.2.  `ENV['RAILS_ENV']` is not guaranteed to be set (it is not in a default development environment).

This commit checks for the existence of a `Rails` constant, and if found and it responds to `.env`, prefer that value as the current environment.

This ensures that the per-environment selection continues to work under Rails 3.2+.
