### PR TITLE
Add support for graceful shutdown via TERM 

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -366,6 +366,8 @@ module Resque
     def create_worker(queues)
       queues = queues.to_s.split(',')
       worker = ::Resque::Worker.new(*queues)
+      worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
+      worker.term_child = ENV['TERM_CHILD']
       worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       worker.very_verbose = ENV['VVERBOSE']
       worker


### PR DESCRIPTION
See http://hone.heroku.com/resque/2012/08/21/resque-signals.html

It's just a matter of passing down the ENV variable for TERM_CHILD to a property on the Worker.  Foreman, and suchlike, can then just send SIGTERM to the pool master, which will ultimately raise a SignalException in the worker children, allowing graceful handling of shutdown.
