### PR TITLE
match the task dependency in resque:work

### DIFF
--- a/lib/resque/pool/tasks.rb
+++ b/lib/resque/pool/tasks.rb
@@ -12,7 +12,7 @@ namespace :resque do
   end
 
   desc "Launch a pool of resque workers"
-  task :pool => %w[resque:setup resque:pool:setup] do
+  task :pool => %w[resque:preload resque:setup resque:pool:setup] do
     require 'resque/pool'
     Resque::Pool.run
   end


### PR DESCRIPTION
Otherwise, each child job need to load the classes, which takes very long time depending on the setup (at least in a reasonably big rails project).
