### PR TITLE
Fixing deprecation warnings

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -394,8 +394,12 @@ module Resque
       worker = ::Resque::Worker.new(*queues)
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']
-      worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
-      worker.very_verbose = ENV['VVERBOSE']
+      if ENV['LOGGING'] || ENV['VERBOSE']
+        worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
+      end
+      if ENV['VVERBOSE']
+        worker.very_verbose = ENV['VVERBOSE']
+      end
       worker
     end
 


### PR DESCRIPTION
Fixes some deprecation warnings in the newer versions of Resque

```
*** DEPRECATION WARNING: Resque::Worker#verbose and #very_verbose are deprecated. Please set Resque.logger.level instead
Called from: ***/.rvm/gems/ruby-2.0.0-p195@ru-bee/gems/resque-1.24.1/lib/resque/worker.rb:649:in `verbose='
```

This implementation is the same as Resque's - https://github.com/resque/resque/pull/757/files
