### PR TITLE
Allow for multiple hooks in after_prefork

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -28,24 +28,27 @@ module Resque
 
     # Config: after_prefork {{{
 
-    # The `after_prefork` hook will be run in workers if you are using the
-    # preforking master worker to save memory. Use this hook to reload
+    # The `after_prefork` hooks will be run in workers if you are using the
+    # preforking master worker to save memory. Use these hooks to reload
     # database connections and so forth to ensure that they're not shared
     # among workers.
     #
-    # Call with a block to set the hook.
-    # Call with no arguments to return the hook.
+    # Call with a block to set a hook.
+    # Call with no arguments to return all registered hooks.
     def self.after_prefork(&block)
-      block ? (@after_prefork = block) : @after_prefork
+      @after_prefork ||= []
+      block ? (@after_prefork << block) : @after_prefork
     end
 
     # Set the after_prefork proc.
     def self.after_prefork=(after_prefork)
-      @after_prefork = after_prefork
+      @after_prefork << after_prefork
     end
 
     def call_after_prefork!
-      self.class.after_prefork && self.class.after_prefork.call
+      self.class.after_prefork.each do |hook|
+        hook.call
+      end
     end
 
     # }}}

--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -164,3 +164,38 @@ describe Resque::Pool, "when loading the pool configuration from a file" do
   end
 
 end
+
+describe Resque::Pool, "given after_prefork hook" do
+  subject { Resque::Pool.new(nil) }
+
+  context "with a single hook" do
+    before { Resque::Pool.after_prefork { @called = true } }
+
+    it "should call prefork" do
+      subject.call_after_prefork!
+      @called.should == true
+    end
+  end
+
+  context "with a single hook by attribute writer" do
+    before { Resque::Pool.after_prefork = Proc.new { @called = true } }
+
+    it "should call prefork" do
+      subject.call_after_prefork!
+      @called.should == true
+    end
+  end
+
+  context "with multiple hooks" do
+    before {
+      Resque::Pool.after_prefork { @called_first = true }
+      Resque::Pool.after_prefork { @called_second = true }
+    }
+
+    it "should call both" do
+      subject.call_after_prefork!
+      @called_first.should == true
+      @called_second.should == true
+    end
+  end
+end


### PR DESCRIPTION
Existing versions of Resque::Pool will only allow one caller to set the
`after_prefork` hook. When this is used for something like reestablishing the
ActiveRecord connection, it prevents other libraries from safely registering
their own hook.

I met Jonathan Julian (@jjulian) at RubyNation during a code and coffee event, and
after some conversation decided to dig into why `newrelic_rpm` (which I work
on) wasn't compatible with `resque-pool`. At one point I thought we would need
multiple hooks to get things working, but I've actually managed a fix in the upcoming
agent version that won't require any changes to `resque-pool`. :triumph: 

I still think this change is worthwhile even if it's not required for New Relic
support. Resque itself had a similar issue with only allowing on `after_fork`
hook, and it caused us no end of grief when our hooks got tromped by other
libraries and app code.
