### PR TITLE
Fix order dependent specs

### DIFF
--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -6,6 +6,7 @@ RSpec.configure do |config|
     ENV.delete 'RACK_ENV'
     ENV.delete 'RAILS_ENV'
     ENV.delete 'RESQUE_ENV'
+    ENV.delete 'RESQUE_POOL_CONFIG'
   }
 end
 


### PR DESCRIPTION
If a particular developer has `--order rand` in his global Rspec config (e.g. `~/.rspec`), then sometimes the specs failed because the environment variable `RESQUE_POOL_CONFIG` for the pool config was not cleaned up. This fixes this issue.
