### PR TITLE
Strange bug with starting resque-pool

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -386,7 +386,7 @@ module Resque
     end
 
     def worker_delta_for(queues)
-      config.fetch(queues, 0) - workers.fetch(queues, []).size
+      (config.fetch(queues, 0) || 0) - workers.fetch(queues, []).size
     end
 
     def pids_for(queues)


### PR DESCRIPTION
Hi,

We've run into a bug here using `resque-pool`:

```
resque-pool-0.3.0/lib/resque/pool.rb:312:in `worker_delta_for': undefined method `-' for nil:NilClass (NoMethodError)
```

I haven't been able to fully understand the issue where here's how the `config` object looks at line `312`:

```
{"ac446872-4ad9-4f69-b075-a8017aa9e049"=>1, "foo-1"=>nil}
```

The function is called for `foo-1` so we get `nil` and boom.

This PR is a naive fix.. Maybe there's a better way to deal with this issue?
