### PR TITLE
Add support for worker pre_shutdown_timeout

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -443,6 +443,10 @@ module Resque
       worker = ::Resque::Worker.new(*queues)
       worker.pool_master_pid = Process.pid
       worker.term_timeout = (ENV['RESQUE_TERM_TIMEOUT'] || 4.0).to_f
+      if worker.respond_to?(:pre_shutdown_timeout)
+        # resque doesn't support this until 1.27.3, but we support 1.22
+        worker.pre_shutdown_timeout = (ENV['RESQUE_PRE_SHUTDOWN_TIMEOUT'] || 0.0).to_f
+      end
       worker.term_child = ENV['TERM_CHILD']
       if worker.respond_to?(:run_at_exit_hooks=)
         # resque doesn't support this until 1.24, but we support 1.22


### PR DESCRIPTION
Resque has had support for a `pre_shutdown_timeout` for a worker since v1.27.3 (https://github.com/resque/resque/pull/1514). 

> The time between the parent receiving a shutdown signal (TERM by default) and it sending that signal on to the child process. Designed to give the child process time to complete before being forced to die.

This PR adds support for this attribute in the forked workers.