### PR TITLE
Update gemspec metadata

### DIFF
--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.name        = "resque-pool"
   spec.version     = Resque::Pool::VERSION
   spec.authors     = ["nicholas a. evans",]
-  spec.email       = ["nick@ekenosen.net"]
+  spec.email       = ["nick@rubinick.dev"]
 
   spec.summary     = "quickly and easily fork a pool of resque workers"
   spec.description = <<-EOF

--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "http://github.com/resque/resque-pool"
   spec.metadata["changelog_uri"] = "https://github.com/resque/resque-pool/blob/main/Changelog.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency "resque", ">= 1.22", "< 3"
-  spec.add_dependency "rake",   ">= 10.0", "< 14.0"
+  spec.add_dependency "rake",   ">= 10.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec"

--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |spec|
     quickly and easily fork a pool of resque workers,
     saving memory (w/REE) and monitoring their uptime
   EOF
-  spec.homepage    = "http://github.com/nevans/resque-pool"
+  spec.homepage    = "http://github.com/resque/resque-pool"
   spec.license     = 'MIT'
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "http://github.com/nevans/resque-pool"
+  spec.metadata["source_code_uri"] = "http://github.com/resque/resque-pool"
   spec.metadata["changelog_uri"] = "https://github.com/resque/resque-pool/blob/main/Changelog.md"
 
   # Specify which files should be added to the gem when it is released.

--- a/resque-pool.gemspec
+++ b/resque-pool.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "http://github.com/nevans/resque-pool"
-  spec.metadata["changelog_uri"] = "https://github.com/resque/resque/blob/master/HISTORY.md"
+  spec.metadata["changelog_uri"] = "https://github.com/resque/resque-pool/blob/main/Changelog.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
* **📚 Fix Changelog URI in gemspec metadata**
  This was previously pointing to the `resque` repo's History.md file!
* **📧 Update my email in the gemspec**
  This is the email I have configured for my rubygems.org account.
* **📚 Update gemspec URIs with transferred repo owner**
  This repo was transferred from my github user (`nevans`) to the `resque` organization.
* **🔒 Explicitly require MFA to publish gem**
  I believe this was probably already _implicitly_ required, but putting it in the gemspec metadata helps tooling (which might audit for this) and will be reflected on the rubygems.org web site.
* **⬆️ Relax rake gem dependency constraint**
  It is _very_ unlikely that rake will be updated in an incompatible way.